### PR TITLE
Make clang-tidy version configurable & support Ubuntu 24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        runner: [ ubuntu-22.04, ubuntu-24.04 ]
         reporter: [ github-check, github-pr-review, github-pr-annotations ]
 
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -28,3 +29,28 @@ jobs:
           workdir: ./test/build
           reporter: ${{ matrix.reporter }}
           fail_on_error: false
+
+      # reviewdog runs with fail_on_error: false above, so a broken log would
+      # otherwise go unnoticed. remove_duplicate_error.py splits the raw log on
+      # the clang-tidy binary name and silently emits the whole log twice when
+      # that marker does not match (str.find returns -1), so assert the parsed
+      # log explicitly.
+      - name: assert clang-tidy log was parsed
+        working-directory: ./test/build
+        run: |
+          cat clang_tidy.log
+
+          # dedup can only ever remove content
+          raw="$(wc -c < clang_tidy_raw.log)"
+          out="$(wc -c < clang_tidy.log)"
+          echo "raw=${raw} parsed=${out}"
+          if [ "$out" -gt "$raw" ]; then
+            echo "::error::parsed log is larger than the raw log; the clang-tidy marker did not match"
+            exit 1
+          fi
+
+          # the known diagnostics in test/main.c must survive parsing
+          if ! grep -qE 'main\.c:[0-9]+:[0-9]+: warning:' clang_tidy.log; then
+            echo "::error::no warning for test/main.c found in the parsed log"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -25,3 +25,25 @@ jobs:
     - name: Build
      run: cmake --build ./build
 ```
+
+## clang-tidy version
+
+`clang-tidy` is installed from the runner's apt repositories, so the available
+versions depend on the Ubuntu release:
+
+| | Ubuntu 22.04 | Ubuntu 24.04 |
+|---|---|---|
+| `clang-tidy-11` | ✅ | ❌ not packaged |
+| `clang-tidy-14` | ✅ | ✅ |
+| `clang-tidy-18` | ❌ not packaged | ✅ |
+
+`clang_tidy_version` defaults to `14`, the only version packaged by both, so
+the action works on `ubuntu-22.04`, `ubuntu-24.04` and `ubuntu-latest`.
+Override it to pick a different one:
+
+```yaml
+    - uses: arkedge/action-clang-tidy
+      with:
+        workdir: ./build
+        clang_tidy_version: '18'   # ubuntu-24.04 only
+```

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,12 @@ inputs:
   workdir:
     description: 'working directory'
     default: '.'
+  clang_tidy_version:
+    description: |
+      Version suffix of the clang-tidy apt package to install (e.g. 14 installs
+      clang-tidy-14 and runs run-clang-tidy-14).
+      14 is the only version packaged by both Ubuntu 22.04 and 24.04.
+    default: '14'
   tool_name:
     description: 'reviewdog name'
     default: 'clang-tidy'
@@ -46,20 +52,20 @@ runs:
     - name: install clang-tidy
       #if: runner.os == 'Linux'
       shell: bash
-      run: sudo apt-get install -y clang-tidy-11
+      run: sudo apt-get install -y clang-tidy-${{ inputs.clang_tidy_version }}
 
     - name: Run clang-tidy
       continue-on-error: true
       shell: bash
       working-directory: ${{ inputs.workdir }}
       run: |
-        run-clang-tidy-11 \
+        run-clang-tidy-${{ inputs.clang_tidy_version }} \
           | sed "s|$(pwd)/||g" > clang_tidy_raw.log
 
     - name: Remove clang-tidy duplicate error
       shell: bash
       run: |
-        python ${{ github.action_path }}/remove_duplicate_error.py ${{ inputs.workdir }}/clang_tidy_raw.log "clang-tidy-11" \
+        python3 ${{ github.action_path }}/remove_duplicate_error.py ${{ inputs.workdir }}/clang_tidy_raw.log "clang-tidy-${{ inputs.clang_tidy_version }}" \
           | tee ${{ inputs.workdir }}/clang_tidy.log
 
     - name: reviewdog

--- a/action.yml
+++ b/action.yml
@@ -59,8 +59,14 @@ runs:
       shell: bash
       working-directory: ${{ inputs.workdir }}
       run: |
+        # run-clang-tidy passes --use-color to clang-tidy from version 14 on,
+        # even when stdout is a pipe. The escape sequences land between the
+        # position and the severity, so reviewdog's
+        # -efm="%W%f:%l:%c: warning: %m" stops matching and nothing gets
+        # reported. Strip them rather than relying on a --use-color flag that
+        # not every clang-tidy version accepts.
         run-clang-tidy-${{ inputs.clang_tidy_version }} \
-          | sed "s|$(pwd)/||g" > clang_tidy_raw.log
+          | sed -e "s|$(pwd)/||g" -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' > clang_tidy_raw.log
 
     - name: Remove clang-tidy duplicate error
       shell: bash


### PR DESCRIPTION
## Problem

`clang-tidy-11` は **Ubuntu 24.04 (noble) にパッケージが存在しません**。そのため `sudo apt-get install -y clang-tidy-11` が失敗し、この action は `ubuntu-24.04` / `ubuntu-latest` では**一切動きません**。README のサンプルは `runs-on: ubuntu-latest` なので、現在それをそのまま使うと壊れます。

これが #36 (Update dependency ubuntu to v24) が落ちている原因であり、下流の `arkedge/workflows-c2a` の ubuntu v24 更新もこれで止まっています。

| | Ubuntu 22.04 (jammy) | Ubuntu 24.04 (noble) |
|---|---|---|
| `clang-tidy-11` | ✅ `1:11.1.0-6` | ❌ *Package not available in this suite* |
| `clang-tidy-14` | ✅ `1:14.0.0-1ubuntu1.1` | ✅ `1:14.0.6-19build4` |
| `clang-tidy-18` | ❌ not packaged | ✅ `1:18.1.3-1` |

## Change

`clang_tidy_version` input を追加し、**apt パッケージ名・`run-clang-tidy-N` バイナリ名・`remove_duplicate_error.py` に渡すマーカー文字列**の3箇所すべてに使います（これらは常に一致していなければならないため）。

default は **`14`**（22.04 と 24.04 の両方にある唯一のバージョン）。これにより `ubuntu-22.04` / `ubuntu-24.04` / `ubuntu-latest` すべてで動きます。`/usr/bin/run-clang-tidy-14` は両 suite のパッケージに含まれることを確認済みです。

`remove_duplicate_error.py` の起動を `python` → `python3` に変更しました。両ランナーイメージで確実に存在するのは `python3` のみです。

## テストを強化しました

これは意図的に含めています。`remove_duplicate_error.py` は **clang-tidy バイナリ名でログを split して**診断ブロックを見つけます:

```python
print(s[:s.find(cc_cmd)], end="")
s = s[s.find(cc_cmd):]
log = s.split(cc_cmd)
```

マーカーが一致しないと `str.find` が `-1` を返し、**例外を投げずにログ全体を2回出力**します。既存のテストは reviewdog に `fail_on_error: false` を渡しているので、この壊れ方は**何にも検出されません**。バージョンを可変にする変更でここを放置するのは危険なので、アサーションを追加しました:

1. `clang_tidy.log` が `clang_tidy_raw.log` より大きくないこと（dedup は内容を減らすことしかできない不変条件。マーカーが外れると約2倍になる）
2. `test/main.c` の既知の warning がパース後も残っていること

さらに test matrix を `ubuntu-22.04` / `ubuntu-24.04` の2ランナーに拡張したので、サポート対象が両方 CI で検証されます（3 reporter × 2 runner = 6 ジョブ）。

## 判断が必要な点

**default を `14` にするかどうかは方針の判断が必要です。** 既存利用者は clang-tidy 11 → 14 になり、検出される診断が変わります（増える可能性が高い）。下流リポジトリの CI が賑やかになるかもしれません。

保守的にしたい場合は `default: '14'` を `default: '11'` にするだけで、**挙動を完全に維持したまま opt-in** にできます。ただしその場合 `ubuntu-latest` / 24.04 は引き続き壊れたままになります。バージョンタグをどう切るか（minor か major か）も含めて判断してください。

`actionlint` はローカルで通しています。

## Related

- #36 Update dependency ubuntu to v24 — この PR が入れば通るはず
- #38 Update reviewdog/action-setup action to v1.5.0 — 独立

🤖 Generated with [Claude Code](https://claude.com/claude-code)
