### PR TITLE
Add fail_level input for reviewdog -fail-level

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,46 @@ jobs:
           workdir: ./test/build
           reporter: ${{ matrix.reporter }}
           fail_on_error: false
+
+  # test/main.c always produces warnings, so fail_level decides whether the
+  # step fails. Assert both directions so the flag cannot silently stop being
+  # passed to reviewdog.
+  test-fail-level:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - fail_level: none
+            expected: success
+          - fail_level: any
+            expected: failure
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: CMake
+        env:
+          CC: clang
+        working-directory: test
+        run: cmake -B ./build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - uses: ./
+        id: clang_tidy
+        continue-on-error: true
+        with:
+          workdir: ./test/build
+          reporter: github-check
+          fail_level: ${{ matrix.fail_level }}
+
+      - name: assert outcome
+        env:
+          OUTCOME: ${{ steps.clang_tidy.outcome }}
+          EXPECTED: ${{ matrix.expected }}
+        run: |
+          echo "fail_level=${{ matrix.fail_level }} outcome=${OUTCOME} expected=${EXPECTED}"
+          if [ "${OUTCOME}" != "${EXPECTED}" ]; then
+            echo "::error::expected ${EXPECTED} with fail_level=${{ matrix.fail_level }}, got ${OUTCOME}"
+            exit 1
+          fi

--- a/action.yml
+++ b/action.yml
@@ -26,8 +26,20 @@ inputs:
     description: 'reviewdog filter_mode'
     default: 'nofilter'
   fail_on_error:
-    description: 'exit code for reviewdog on error'
+    description: |
+      exit code for reviewdog on error.
+      Deprecated by reviewdog in favour of fail_level; only used when
+      fail_level is empty.
     default: 'true'
+  fail_level:
+    description: |
+      reviewdog fail_level [none,any,info,warning,error].
+      Takes precedence over fail_on_error when set. Requires reviewdog
+      v0.20.2 or later, which is where -fail-level was introduced.
+      Note that reviewdog v0.19.0 changed -fail-on-error for the
+      github-[pr-]check reporters to exit 1 on any severity, so
+      fail_level=error is what restores the pre-v0.19.0 behaviour there.
+    default: ''
   reviewdog_version:
     description: 'reviewdog version'
     default: 'latest'
@@ -68,10 +80,18 @@ runs:
       env:
         REVIEWDOG_GITHUB_API_TOKEN: ${{ inputs.github_token }}
       run: |
+        # -fail-on-error is deprecated since reviewdog v0.20.2 in favour of
+        # -fail-level. Pass exactly one of them, never both.
+        if [ -n "${{ inputs.fail_level }}" ]; then
+          fail_flag="-fail-level=${{ inputs.fail_level }}"
+        else
+          fail_flag="-fail-on-error=${{ inputs.fail_on_error }}"
+        fi
+
         reviewdog \
           -name "${{ inputs.tool_name }}" \
           -level "${{ inputs.level }}" \
-          -fail-on-error="${{ inputs.fail_on_error }}" \
+          "${fail_flag}" \
           -filter-mode="${{ inputs.filter_mode }}" \
           -diff="git diff FETCH_HEAD" \
           -reporter="${{ inputs.reporter }}" \


### PR DESCRIPTION
## Problem

reviewdog は **v0.20.2 で `-fail-on-error` を deprecated** にし、`-fail-level=[none,any,info,warning,error]` を後継としました。

さらに **v0.19.0 で `-fail-on-error` の挙動自体が変わっています**（CHANGELOG の Breaking changes）:

> the behavior of `-fail-on-error` changed with `-github-[pr-]check`. Previously, reviewdog didn't exit with 1 if it find issues with warning and info level. **Now reviewdog will exit with 1 with any level.** The previous behavior can be restored with `-fail-level=error` flag

つまり `github-check` / `github-pr-check` reporter を使っていて warning が出るコードベースでは、reviewdog を v0.19.0 以降に上げた瞬間に CI が落ち始めます。それを避ける手段は `-fail-level=error` ですが、**この action にはそれを指定する方法がありませんでした。**

これは下流の `arkedge/workflows-c2a` で実際に問題になっています。あちらは reviewdog を `v0.16.0` に固定したまま1年9ヶ月動いており、Wextra レーンが `github-check` + `nofilter` + warning 2件という、まさにこの breaking change を踏む構成です。

## Change

`fail_level` input を追加します。設定されていれば `fail_on_error` より優先されます。

```yaml
    - uses: arkedge/action-clang-tidy
      with:
        workdir: ./build
        fail_level: error   # warning では落とさない
```

**2つのフラグは排他で、必ず片方だけを渡します。** deprecated なフラグとその後継を同時に渡した場合の挙動は reviewdog が何も保証していないためです。

`fail_level` が空（default）のときは従来どおり `-fail-on-error` を渡すので、**既存の呼び出し元の挙動は一切変わりません。**

## テスト

`test/main.c` は必ず warning を出すので、`fail_level` だけが step の成否を決めます。両方向をテストしました:

| `fail_level` | 期待 |
|---|---|
| `none` | success |
| `any` | failure |

`continue-on-error: true` + `steps.<id>.outcome` の突き合わせで検証しているので、**フラグが reviewdog に届かなくなったら CI が落ちます**。

## Notes

- `fail_level` は **reviewdog v0.20.2 以降が必要**です（`-fail-level` の導入バージョン）。それより古い reviewdog に渡すと `flag provided but not defined` になります。`reviewdog_version` を古いバージョンに固定している呼び出し元は、先に reviewdog を上げる必要があります。input の description にも書いてあります
- #45 と `.github/workflows/test.yml` の同じ挿入位置を触るため、**軽微な conflict になります**。どちらを先にマージしても解決は数行です。独立してマージできる方が良いと判断して、あえて #45 に stack させていません
- `actionlint` はローカルで通しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)