### PR TITLE
Pin GitHub Action digests & migrate renovate preset to config:recommended

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,10 +10,10 @@ jobs:
     name: actionlint with reviewdog
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: actionlint
-        uses: reviewdog/action-actionlint@v1.73.0
+        uses: reviewdog/action-actionlint@50842263c20a7c46bd0065b9e624d3c569db061e # v1.73.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7.0.1
-      - uses: actions/setup-node@v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 
       - name: install
         run: |

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
   using: "composite"
   steps:
     - name: install reviewdog
-      uses: reviewdog/action-setup@v1.3.0
+      uses: reviewdog/action-setup@3f401fe1d58fe77e10d665ab713057375e39b887 # v1.3.0
       with:
         reviewdog_version: ${{ inputs.reviewdog_version }}
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "helpers:pinGitHubActionDigests"
   ],
   "additionalReviewers": ["sksat"],
   "assignees": ["sksat"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
+    "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
   "additionalReviewers": ["sksat"],


### PR DESCRIPTION
## What

1. `renovate.json` に **`helpers:pinGitHubActionDigests`** を追加し、Renovate が action 参照を commit digest に pin し続けるようにします
2. 既存の参照を digest に pin します
3. `config:base` → **`config:recommended`**

## Why

タグは action のオーナーが任意のコミットに付け替えられるので、**タグだけでは何も pin できていません**。`test.yml` の `actions/checkout` だけは digest pin されていましたが、残り4箇所はタグ参照でした。

`arkedge/workflows-c2a` は既にこのプリセットを使っており、**4つのうち3つの digest はあちらが独立に pin している値と一致**しました（相互検証になっています）。

## Pinned refs

digest はいずれも現在そのタグが指しているコミットなので、**挙動は変わりません**。

| action | tag | digest | 場所 |
|---|---|---|---|
| `actions/checkout` | v7.0.1 | `3d3c42e…` | actionlint.yml, validate-renovate.yml |
| `actions/setup-node` | v7.0.0 | `8207627…` | validate-renovate.yml |
| `reviewdog/action-setup` | v1.3.0 | `3f401fe…` | **action.yml** |
| `reviewdog/action-actionlint` | v1.73.0 | `5084226…` | actionlint.yml |

`reviewdog/action-actionlint` の v1.73.0 は annotated tag なので、tag object を dereference した commit SHA (`bump v1.73.0`) を使っています。

`action.yml` も Renovate の `github-actions` manager の対象なので（#38 がその証拠）、composite action 側の `reviewdog/action-setup` も追跡され続けます。

## config:recommended

`config:base` は Renovate 36 で `config:recommended` に改名された deprecated alias で、`renovate-config-validator` が `WARN: Config migration necessary` を出していました。純粋な alias なので挙動は変わりません。

検証:
- before: `WARN: Config migration necessary` + `Config validated successfully`
- after: **`Config validated successfully` のみ / exit 0**

`actionlint` もローカルで通しています。

## Notes

- **#38 (Update reviewdog/action-setup to v1.5.0) はこの PR と conflict します。** あちらは `@v1.3.0` というタグ表記を前提に書き換えるためです。この PR がマージされたら Renovate が #38 を digest 表記にリベースし直します。バージョンを上げるかどうかの判断自体は #38 に残ります
- 既存参照を自分で pin したので、Renovate による pin PR を待つ必要はありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)